### PR TITLE
pkgs/rat: rebase

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,6 +48,20 @@
       "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre554642.f5c27c6136db/nixexprs.tar.xz",
       "hash": "1xn9vxizg7w97j6i5ix7629piqhdz9law8rqfa6mnnwg7k8kqb5l"
     },
+    "rat": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "thinkingsand",
+        "repo": "rat"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "version": "2.0.1",
+      "revision": "03d2e16ea0ebe280d7dd472612ced8b4ee71960f",
+      "url": "https://api.github.com/repos/thinkingsand/rat/tarball/2.0.1",
+      "hash": "1lvqr06z2vs48a9hckim12268zfa2d0sckynpn4b0d7lv9hkn2hi"
+    },
     "rofi-calc": {
       "type": "GitRelease",
       "repository": {

--- a/pkgs/rat/default.nix
+++ b/pkgs/rat/default.nix
@@ -1,37 +1,47 @@
 {
-  stdenv,
-  fetchurl,
-  gnused,
-  makeWrapper,
-  pkgs,
-  lib,
   pins,
+  lib,
+  disableHardening ? true,
+  fetchFromGitHub,
+  stdenv,
+  unixtools,
 }:
-stdenv.mkDerivation rec {
+assert disableHardening -> lib.warn "nyxpkgs/rat disables hardening to avoid segfaults. You may want to consider overriding the package if this is undesirable" true; let
+  pin = pins.rat;
+
   pname = "rat";
-  version = "1.1";
+  version = "2.0.1";
+in
+  stdenv.mkDerivation {
+    inherit pname version;
 
-  src = fetchurl {
-    url = "https://github.com/Mcharlsto/rat/releases/download/${version}/rat";
-    sha256 = "sha256-93sspjvXFPocGFPeCF1AWoWYx5hI7vMltx9SQ7x25z4=";
-  };
+    src = fetchFromGitHub {
+      inherit (pin.repository) owner repo;
+      sha256 = pin.hash;
+      rev = pin.revision;
+    };
 
-  buildInputs = [gnused makeWrapper];
+    # the code is so unsafe, it doesn't work with even one of hardening flags
+    # lol
+    hardeningDisable = lib.optionals disableHardening ["all"];
 
-  phases = ["installPhase" "postInstall"];
+    buildInputs = [unixtools.xxd];
+    buildPhase = ''
+      runHook preBuild
+      make linux_audio
+      runHook postBuild
+    '';
 
-  installPhase = ''
-    mkdir -p $out/bin
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      install -Dm755 ./bin/rat -t "$out/bin/"
+      runHook postInstall
+    '';
 
-    cp $src $out/bin/rat
-
-    chmod +x $out/bin/rat
-
-    sed -i '1 s/^.*$/#\/usr\/bin\/env bash/' $out/bin/rat
-  '';
-
-  postInstall = ''
-    wrapProgram $out/bin/rat \
-      --prefix PATH : ${lib.makeBinPath (with pkgs; [sharutils opusfile sox bash])}
-  '';
-}
+    meta = {
+      description = "rat";
+      homepage = "https://github.com/thinkingsand/rat";
+      maintainers = with lib.maintainers; [NotAShelf];
+    };
+  }


### PR DESCRIPTION
Rebase the `rat` package on the C rewrite. Needs hardening disabled, which, in turn needs a warning to inform the user.